### PR TITLE
Add base tag in the index header

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -3,6 +3,8 @@
 <head>
   <%= device_header %>
 
+  <base href='<%= session['url'] %>' />
+
   <!-- Set up required aliases -->
   <script type='text/javascript'>
     var require = {


### PR DESCRIPTION
This allows for the correct loading of images when on a network that redirects
requests.
